### PR TITLE
Session3: Lifecycle

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_training/feature/day_weather/screen.dart';
+import 'package:flutter_training/feature/launch/screen.dart';
 
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
@@ -11,7 +11,7 @@ class MyApp extends StatelessWidget {
       theme: ThemeData(
         primarySwatch: Colors.blue,
       ),
-      home: const DayWeatherScreen(),
+      home: const LaunchScreen(),
     );
   }
 }

--- a/lib/feature/day_weather/screen.dart
+++ b/lib/feature/day_weather/screen.dart
@@ -19,6 +19,10 @@ class _DayWeatherScreenState extends State<DayWeatherScreen> {
     });
   }
 
+  void _onClose() {
+    Navigator.of(context).pop();
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -42,7 +46,7 @@ class _DayWeatherScreenState extends State<DayWeatherScreen> {
                         Flexible(
                           child: Center(
                             child: TextButton(
-                              onPressed: () {},
+                              onPressed: _onClose,
                               child: const Text('Close'),
                             ),
                           ),

--- a/lib/feature/launch/screen.dart
+++ b/lib/feature/launch/screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_training/feature/day_weather/screen.dart';
 
 class LaunchScreen extends StatefulWidget {
   const LaunchScreen({super.key});
@@ -8,6 +9,26 @@ class LaunchScreen extends StatefulWidget {
 }
 
 class LaunchScreenState extends State<LaunchScreen> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.endOfFrame.then((_) => _delayedNavigation());
+  }
+
+  Future<void> _delayedNavigation() async {
+    await Future<void>.delayed(const Duration(milliseconds: 500));
+
+    if (!mounted) {
+      return;
+    }
+    final pageRoute = MaterialPageRoute<String>(
+      builder: (context) => const DayWeatherScreen(),
+    );
+
+    await Navigator.of(context).push(pageRoute);
+    await _delayedNavigation();
+  }
+
   @override
   Widget build(BuildContext context) {
     return Container(

--- a/lib/feature/launch/screen.dart
+++ b/lib/feature/launch/screen.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+class LaunchScreen extends StatefulWidget {
+  const LaunchScreen({super.key});
+
+  @override
+  State<LaunchScreen> createState() => LaunchScreenState();
+}
+
+class LaunchScreenState extends State<LaunchScreen> {
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      color: Colors.green,
+    );
+  }
+}


### PR DESCRIPTION
## 課題

close #4 

## 対応箇所

<!--
課題のどこに対応したか１つ１つ確認しましょう。
-->

- [ ] [StatefulWidget](https://api.flutter.dev/flutter/widgets/StatefulWidget-class.html) を継承した Widget で構築された新しい画面を追加する
 - 新たに`LaunchScreen`を作成しました
- [ ] 新しい画面の背景色は [Colors.green](https://api.flutter.dev/flutter/material/Colors/green-constant.html) に設定する
- [ ] アプリ起動時に新しい画面に遷移する
 - `MaterialApp`の`home`に`LaunchScreen`を配置しました
- [ ] 新しい画面が表示されたら、0.5 秒後に前回まで作っていた画面に遷移する
- [ ] 前回まで作っていた画面の Close ボタンをタップすると画面を閉じる

## 動作

<!--
画像や動画を添付しましょう。
動作に変更なければ、必要ありません。
-->

| expected | actual |
|----------|--------|
| ![demo (1)](https://user-images.githubusercontent.com/54800851/232392226-5bf7c4a6-d968-402d-ad89-dfe15d07878c.gif)      | ![session3](https://user-images.githubusercontent.com/54800851/232392265-de8440bc-f014-49de-9790-6eca0db3a9a9.gif)    |
