### PR TITLE
Session/7 マージ用　再PR

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -9,3 +9,7 @@ targets:
             - implicit_dynamic_type
             - implicit_dynamic_method
             - strict_raw_type
+      json_serializable:
+        options:
+          checked: true
+          field_rename: snake

--- a/build.yaml
+++ b/build.yaml
@@ -1,0 +1,11 @@
+targets:
+  $default:
+    builders:
+      source_gen|combining_builder:
+        options:
+          ignore_for_file:
+            - type=lint
+            - implicit_dynamic_parameter
+            - implicit_dynamic_type
+            - implicit_dynamic_method
+            - strict_raw_type

--- a/lib/common/models/weather.dart
+++ b/lib/common/models/weather.dart
@@ -1,10 +1,9 @@
 import 'package:flutter_training/common/models/weather_condition.dart';
-import 'package:flutter_training/common/utils/extensions/enum.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'weather.freezed.dart';
+part 'weather.g.dart';
 
-/// Model class for weather information
 @freezed
 class Weather with _$Weather {
   factory Weather({
@@ -14,55 +13,6 @@ class Weather with _$Weather {
     required DateTime date,
   }) = _Weather;
 
-  /// Create a [Weather] instance from Json data.
-  ///
-  /// The constructor requires the following Json data.
-  /// ```dart
-  /// const json = {
-  ///    "weather_condition": "cloudy",
-  ///    "max_temperature": 25,
-  ///    "min_temperature": 7,
-  ///    "date": "2020-04-01T12:00:00+09:00"
-  /// }
-  /// ```
-  factory Weather.fromJson(Map<String, dynamic> json) {
-    Never throwFormatException(String message) =>
-        throw FormatException(message);
-
-    final weatherCondition = WeatherCondition.values
-        .byNameOrNull(json['weather_condition'].toString());
-    if (weatherCondition == null) {
-      throwFormatException(
-        '''The value of "weather_condition" must be included in the enum [WeatherCondition].''',
-      );
-    }
-
-    final maxTemperature = int.tryParse(json['max_temperature'].toString());
-    if (maxTemperature == null) {
-      throwFormatException(
-        '''The "max_temperature" value must be numeric.''',
-      );
-    }
-
-    final minTemperature = int.tryParse(json['min_temperature'].toString());
-    if (minTemperature == null) {
-      throwFormatException(
-        '''The "min_temperature" value must be numeric.''',
-      );
-    }
-
-    final date = DateTime.tryParse(json['date'].toString());
-    if (date == null) {
-      throwFormatException(
-        '''The "date" value must be a string in ISO format.''',
-      );
-    }
-
-    return Weather(
-      weatherCondition: weatherCondition,
-      maxTemperature: maxTemperature,
-      minTemperature: minTemperature,
-      date: date,
-    );
-  }
+  factory Weather.fromJson(Map<String, dynamic> json) =>
+      _$WeatherFromJson(json);
 }

--- a/lib/common/models/weather.freezed.dart
+++ b/lib/common/models/weather.freezed.dart
@@ -14,6 +14,10 @@ T _$identity<T>(T value) => value;
 final _privateConstructorUsedError = UnsupportedError(
     'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
 
+Weather _$WeatherFromJson(Map<String, dynamic> json) {
+  return _Weather.fromJson(json);
+}
+
 /// @nodoc
 mixin _$Weather {
   WeatherCondition get weatherCondition => throw _privateConstructorUsedError;
@@ -21,6 +25,7 @@ mixin _$Weather {
   int get minTemperature => throw _privateConstructorUsedError;
   DateTime get date => throw _privateConstructorUsedError;
 
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
   $WeatherCopyWith<Weather> get copyWith => throw _privateConstructorUsedError;
 }
@@ -127,13 +132,16 @@ class __$$_WeatherCopyWithImpl<$Res>
 }
 
 /// @nodoc
-
+@JsonSerializable()
 class _$_Weather implements _Weather {
   _$_Weather(
       {required this.weatherCondition,
       required this.maxTemperature,
       required this.minTemperature,
       required this.date});
+
+  factory _$_Weather.fromJson(Map<String, dynamic> json) =>
+      _$$_WeatherFromJson(json);
 
   @override
   final WeatherCondition weatherCondition;
@@ -163,6 +171,7 @@ class _$_Weather implements _Weather {
             (identical(other.date, date) || other.date == date));
   }
 
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(
       runtimeType, weatherCondition, maxTemperature, minTemperature, date);
@@ -172,6 +181,13 @@ class _$_Weather implements _Weather {
   @pragma('vm:prefer-inline')
   _$$_WeatherCopyWith<_$_Weather> get copyWith =>
       __$$_WeatherCopyWithImpl<_$_Weather>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$_WeatherToJson(
+      this,
+    );
+  }
 }
 
 abstract class _Weather implements Weather {
@@ -180,6 +196,8 @@ abstract class _Weather implements Weather {
       required final int maxTemperature,
       required final int minTemperature,
       required final DateTime date}) = _$_Weather;
+
+  factory _Weather.fromJson(Map<String, dynamic> json) = _$_Weather.fromJson;
 
   @override
   WeatherCondition get weatherCondition;

--- a/lib/common/models/weather.g.dart
+++ b/lib/common/models/weather.g.dart
@@ -1,0 +1,44 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, implicit_dynamic_parameter, implicit_dynamic_type, implicit_dynamic_method, strict_raw_type
+
+part of 'weather.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$_Weather _$$_WeatherFromJson(Map<String, dynamic> json) => $checkedCreate(
+      r'_$_Weather',
+      json,
+      ($checkedConvert) {
+        final val = _$_Weather(
+          weatherCondition: $checkedConvert('weather_condition',
+              (v) => $enumDecode(_$WeatherConditionEnumMap, v)),
+          maxTemperature: $checkedConvert('max_temperature', (v) => v as int),
+          minTemperature: $checkedConvert('min_temperature', (v) => v as int),
+          date: $checkedConvert('date', (v) => DateTime.parse(v as String)),
+        );
+        return val;
+      },
+      fieldKeyMap: const {
+        'weatherCondition': 'weather_condition',
+        'maxTemperature': 'max_temperature',
+        'minTemperature': 'min_temperature'
+      },
+    );
+
+Map<String, dynamic> _$$_WeatherToJson(_$_Weather instance) =>
+    <String, dynamic>{
+      'weather_condition':
+          _$WeatherConditionEnumMap[instance.weatherCondition]!,
+      'max_temperature': instance.maxTemperature,
+      'min_temperature': instance.minTemperature,
+      'date': instance.date.toIso8601String(),
+    };
+
+const _$WeatherConditionEnumMap = {
+  WeatherCondition.sunny: 'sunny',
+  WeatherCondition.rainy: 'rainy',
+  WeatherCondition.cloudy: 'cloudy',
+};

--- a/lib/feature/day_weather/repository.dart
+++ b/lib/feature/day_weather/repository.dart
@@ -24,9 +24,15 @@ class DayWeatherRepository {
 
     try {
       final response = _client.fetchWeather(jsonPayload);
-      final json = jsonDecode(response) as Map<String, dynamic>;
-      final weather = Weather.fromJson(json);
-      return Result.success(weather);
+      try {
+        final json = jsonDecode(response) as Map<String, dynamic>;
+        final weather = Weather.fromJson(json);
+        return Result.success(weather);
+      } on CheckedFromJsonException catch (error) {
+        SimpleLogger().info('\nFetched Response: $response');
+        SimpleLogger().shout(error);
+        return const Result.failure('不適切なデータを取得しました');
+      }
     } on YumemiWeatherError catch (error) {
       SimpleLogger().shout(error);
       switch (error) {
@@ -35,9 +41,6 @@ class DayWeatherRepository {
         case YumemiWeatherError.unknown:
           return const Result.failure('不明なエラーが発生しました');
       }
-    } on CheckedFromJsonException catch (error) {
-      SimpleLogger().shout(error);
-      return const Result.failure('不適切なデータを取得しました');
     }
   }
 }

--- a/lib/feature/day_weather/repository.dart
+++ b/lib/feature/day_weather/repository.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:flutter_training/common/models/result.dart';
 import 'package:flutter_training/common/models/weather.dart';
 import 'package:flutter_training/common/models/weather_condition.dart';
+import 'package:json_annotation/json_annotation.dart';
 import 'package:simple_logger/simple_logger.dart';
 import 'package:yumemi_weather/yumemi_weather.dart';
 
@@ -34,7 +35,7 @@ class DayWeatherRepository {
         case YumemiWeatherError.unknown:
           return const Result.failure('不明なエラーが発生しました');
       }
-    } on FormatException catch (error) {
+    } on CheckedFromJsonException catch (error) {
       SimpleLogger().shout(error);
       return const Result.failure('不適切なデータを取得しました');
     }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -308,13 +308,21 @@ packages:
     source: hosted
     version: "0.6.5"
   json_annotation:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: json_annotation
       sha256: c33da08e136c3df0190bd5bbe51ae1df4a7d96e7954d1d7249fea2968a72d317
       url: "https://pub.dev"
     source: hosted
     version: "4.8.0"
+  json_serializable:
+    dependency: "direct dev"
+    description:
+      name: json_serializable
+      sha256: dadc08bd61f72559f938dd08ec20dbfec6c709bba83515085ea943d2078d187a
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.6.1"
   lints:
     dependency: transitive
     description:
@@ -456,6 +464,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.7"
+  source_helper:
+    dependency: transitive
+    description:
+      name: source_helper
+      sha256: "3b67aade1d52416149c633ba1bb36df44d97c6b51830c2198e934e3fca87ca1f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.3"
   source_span:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
   flutter_svg: ^2.0.5
 
   freezed_annotation: ^2.2.0
+  json_annotation: ^4.8.0
   simple_logger: ^1.9.0+2
   yumemi_weather:
     git:
@@ -26,6 +27,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   freezed: ^2.3.2
+  json_serializable: ^6.6.1
 
 flutter:
   uses-material-design: true


### PR DESCRIPTION
## 概要
- #20 

上記Session7のPRを間違ったブランチにマージした。
そのため、`main`ブランチにマージをするためのPRを出します。

## 経緯
`session/6`ブランチがマージされる前に`session/7`ブランチのPRを作成した。
その際、差分を消すためマージ先を`session/7`->`session/6`にした。

自分の認識では、`session/6`のブランチがマージされると、`session/7`のマージ先が自動的に`main`ブランチになると思っていた。
しかし、実際には`session/6`のままで、それ気づかず誤ってマージした。

もしかしたら、`session/6`をマージした後に`session/7`を`main`ブランチでリベースしたことが原因なのかもしれない。