### PR TITLE
refactor: Add initial value provider

### DIFF
--- a/lib/feature/day_weather/presentation/presenter/day_weather_provider.dart
+++ b/lib/feature/day_weather/presentation/presenter/day_weather_provider.dart
@@ -18,10 +18,16 @@ FetchDayWeatherUseCase fetchDayWeatherUseCase(FetchDayWeatherUseCaseRef ref) =>
     FetchDayWeatherUseCase(ref.watch(dayWeatherRepositoryProvider));
 
 @riverpod
+ApiCallStatus<Result<Weather, String>> dayWeatherApiCallInitialValue(
+  DayWeatherApiCallInitialValueRef ref,
+) =>
+    const ApiCallStatus<Result<Weather, String>>.notLoaded();
+
+@riverpod
 class DayWeatherApiCallState extends _$DayWeatherApiCallState {
   @override
   ApiCallStatus<Result<Weather, String>> build() =>
-      const ApiCallStatus.notLoaded();
+      ref.watch(dayWeatherApiCallInitialValueProvider);
 
   Future<void> fetchWeather() async {
     if (state.isLoading) {

--- a/lib/feature/day_weather/presentation/presenter/day_weather_provider.g.dart
+++ b/lib/feature/day_weather/presentation/presenter/day_weather_provider.g.dart
@@ -41,7 +41,25 @@ final fetchDayWeatherUseCaseProvider =
 );
 
 typedef FetchDayWeatherUseCaseRef = ProviderRef<FetchDayWeatherUseCase>;
-String _$dayWeatherHash() => r'c9bd0b96015abbd03a86791fa7b005990a819e73';
+String _$dayWeatherApiCallInitialValueHash() =>
+    r'cde6d1bfe4e9e6594ba3cbdb681c88325ac74047';
+
+/// See also [dayWeatherApiCallInitialValue].
+@ProviderFor(dayWeatherApiCallInitialValue)
+final dayWeatherApiCallInitialValueProvider =
+    AutoDisposeProvider<ApiCallStatus<Result<Weather, String>>>.internal(
+  dayWeatherApiCallInitialValue,
+  name: r'dayWeatherApiCallInitialValueProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$dayWeatherApiCallInitialValueHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef DayWeatherApiCallInitialValueRef
+    = AutoDisposeProviderRef<ApiCallStatus<Result<Weather, String>>>;
+String _$dayWeatherHash() => r'5a5a21a24e7610e4c712a4159d525e88307292f9';
 
 /// See also [dayWeather].
 @ProviderFor(dayWeather)
@@ -56,7 +74,7 @@ final dayWeatherProvider = AutoDisposeProvider<Weather?>.internal(
 
 typedef DayWeatherRef = AutoDisposeProviderRef<Weather?>;
 String _$dayWeatherApiCallStateHash() =>
-    r'db8ad8bad08204c77bdf569857fa1d752c769925';
+    r'2ffe24749e5cf335eb297d1fde286acdbe91836a';
 
 /// See also [DayWeatherApiCallState].
 @ProviderFor(DayWeatherApiCallState)

--- a/test/feature/day_weather/presentation/presenter/day_weather_provider_test.dart
+++ b/test/feature/day_weather/presentation/presenter/day_weather_provider_test.dart
@@ -25,12 +25,9 @@ class RiverpodTestTools {
           overrides: [
             fetchDayWeatherUseCaseProvider.overrideWithValue(useCaseMock),
             dayWeatherApiCallInitialValueProvider,
-            ...initialState == null
-                ? []
-                : [
-                    dayWeatherApiCallInitialValueProvider
-                        .overrideWithValue(initialState)
-                  ]
+            if (initialState != null)
+              dayWeatherApiCallInitialValueProvider
+                  .overrideWithValue(initialState)
           ],
         ) {
     addTearDown(container.dispose);

--- a/test/feature/day_weather/presentation/presenter/day_weather_provider_test.dart
+++ b/test/feature/day_weather/presentation/presenter/day_weather_provider_test.dart
@@ -20,9 +20,17 @@ class Listener<T> extends Mock {
 class RiverpodTestTools {
   RiverpodTestTools({
     required FetchDayWeatherUseCase useCaseMock,
+    ApiCallStatus<Result<Weather, String>>? initialState,
   }) : container = ProviderContainer(
           overrides: [
             fetchDayWeatherUseCaseProvider.overrideWithValue(useCaseMock),
+            dayWeatherApiCallInitialValueProvider,
+            ...initialState == null
+                ? []
+                : [
+                    dayWeatherApiCallInitialValueProvider
+                        .overrideWithValue(initialState)
+                  ]
           ],
         ) {
     addTearDown(container.dispose);
@@ -234,23 +242,19 @@ void main() {
 
     test('State retains previous value during loading', () async {
       // Arrange
+      final resultSuccess = Result<Weather, String>.success(weather);
       final riverpodTestTools = RiverpodTestTools(
         useCaseMock: useCaseMock,
+        // 初期値を変更
+        initialState: ApiCallStatus.loaded(resultSuccess),
       );
-      final fetchCompleter = Completer<Result<Weather, String>>();
-
-      // 初期値を変更
-      final resultSuccess = Result<Weather, String>.success(weather);
-      when(useCaseMock.call()).thenAnswer((_) async => resultSuccess);
-      await riverpodTestTools.container
-          .read(dayWeatherApiCallStateProvider.notifier)
-          .fetchWeather();
       expect(
         riverpodTestTools.container
             .read(dayWeatherApiCallStateProvider)
             .valueOrNull,
         resultSuccess,
       );
+      final fetchCompleter = Completer<Result<Weather, String>>();
 
       // ローディング状態に変更
       when(useCaseMock.call()).thenAnswer((_) => fetchCompleter.future);


### PR DESCRIPTION
## 対応箇所

<!--
課題のどこに対応したか１つ１つ確認しましょう。
-->
Providerの初期値を持つProviderを作成することで、テストの時にoverrideを使って初期値を上書きできるように変更した。

## 動作
動作の変更はありません
<!--
画像や動画を添付しましょう。
動作に変更なければ、必要ありません。
-->

